### PR TITLE
add missing namespace

### DIFF
--- a/src/DependencyInjection/FlickitySliderExtension.php
+++ b/src/DependencyInjection/FlickitySliderExtension.php
@@ -1,17 +1,17 @@
 <?php
 
+namespace XRayLP\Bundle\FlickitySliderBundle\DependencyInjection;
+
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
-class FlickitySliderExtension  extends ConfigurableExtension 
+class FlickitySliderExtension extends ConfigurableExtension 
 {
     protected function loadInternal(array $mergedConfig, ContainerBuilder $container)
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('service.yml');
     }
-
-    
 }


### PR DESCRIPTION
fixes
```
The autoloader expected class "XRayLP\Bundle\FlickitySliderBundle\DependencyInjection\FlickitySliderExtension" to be defined in file "vendor/composer/../xraylp/contao-flickity-slider/src/DependencyInjection/FlickitySliderExtension.php". The file was found but the class was not in it, the class name or namespace probably has a typo.
```